### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import {BlobWorker, spawn, Thread} from 'threads';
 import WorkerText from './worker'; //May have to @ts-ignore if using TypeScript
 
 //Create a **BLOB WORKER**
-const worker = await spawn(BlobWorker.from(WorkerText));
+const worker = await spawn(BlobWorker.fromText(WorkerText));
 
 console.log(worker.echo('Hello World!')); //Worker received: Hello World!
 


### PR DESCRIPTION
fix static method name: BlobWorker.from -> BlobWorker.fromText

according to https://github.com/andywer/threads.js/commit/79f0e7b212df0560aef3749216ecc35895455317